### PR TITLE
Add biopython dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,21 @@
 from setuptools import setup
 
 setup(
-    name='bam2bw',
-    version='0.4.1',
-    author='Jacob Schreiber',
-    author_email='jmschreiber91@gmail.com',
-    scripts=['bam2bw'],
-    url='https://github.com/jmschrei/bam2bw',
-    license='LICENSE.txt',
-    description='A command-line tool for converting SAM/BAM/fragment.tsv files into un/stranded bp resolution BigWig files. ',
+    name="bam2bw",
+    version="0.4.1",
+    author="Jacob Schreiber",
+    author_email="jmschreiber91@gmail.com",
+    scripts=["bam2bw"],
+    url="https://github.com/jmschrei/bam2bw",
+    license="LICENSE.txt",
+    description="A command-line tool for converting SAM/BAM/fragment.tsv files into un/stranded bp resolution BigWig files. ",
     install_requires=[
+        "biopython",
         "joblib",
         "numpy",
         "pysam",
-		"pyfaidx",
+        "pyfaidx",
         "pyBigWig",
-        "tqdm"
+        "tqdm",
     ],
 )


### PR DESCRIPTION
Addressing bug reported by Alyssa Funk. 

Reproduction:

```
Traceback (most recent call last):
  File "/zata/zippy/ramirezc/.local/share/uv/tools/bam2bw/lib/python3.13/site-packages/pyfaidx/__init__.py", line 523, in __init__
    from Bio import bgzf
ModuleNotFoundError: No module named 'Bio'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/zata/zippy/ramirezc/.local/bin/bam2bw", line 92, in <module>
    fa = pyfaidx.Fasta(args.sizes)
  File "/zata/zippy/ramirezc/.local/share/uv/tools/bam2bw/lib/python3.13/site-packages/pyfaidx/__init__.py", line 1292, in __init__
    self.faidx = Faidx(
                 ~~~~~^
        filename,
        ^^^^^^^^^
    ...<14 lines>...
        rebuild=rebuild,
        ^^^^^^^^^^^^^^^^
        build_index=build_index)
        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/zata/zippy/ramirezc/.local/share/uv/tools/bam2bw/lib/python3.13/site-packages/pyfaidx/__init__.py", line 529, in __init__
    raise ImportError(
        "BioPython >= 1.73 must be installed to read block gzip files.")
ImportError: BioPython >= 1.73 must be installed to read block gzip files.
[ble: exit 1]
```

Solution: Added biopython so in cases where a BGZF compressed fasta is passed to --sizes, pyfaidx works correctly.